### PR TITLE
Hu/07 loan autovalidation

### DIFF
--- a/applications/app-service/src/main/resources/application-aws.yaml
+++ b/applications/app-service/src/main/resources/application-aws.yaml
@@ -1,4 +1,6 @@
 # Configuration for functional testing against a real AWS account
 adapters:
   sqs:
-    queueUrl: "https://sqs.us-east-1.amazonaws.com/096187159240/solicitude-approved-queue"
+    queues:
+      state-change: "https://sqs.us-east-1.amazonaws.com/096187159240/solicitude-approved-queue"
+      debt-capacity: "https://sqs.us-east-1.amazonaws.com/096187159240/debt-capacity-queue"

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -1,5 +1,7 @@
 # Configuration for local development using LocalStack
 adapters:
   sqs:
-    queueUrl: "http://localhost:4566/000000000000/solicitude-approved-queue"
+    queues:
+      state-change: "http://localhost:4566/000000000000/solicitude-approved-queue"
+      debt-capacity: "http://localhost:4566/000000000000/debt-capacity-queue"
     endpoint: "http://localhost:4566"

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -59,3 +59,4 @@ security:
   jwt:
     secret: "${JWT_SECRET:6wmLjTUj5h4CXtp23BPjlr2IouInKGEBhqVi+LkR1KlIisuE4dKm4vbwWhUKwPsg53CjqX5Uu2L8TshpLXPdWA==}"
     expiration: 3600
+

--- a/applications/app-service/src/test/java/co/com/pragma/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/pragma/config/ObjectMapperConfigTest.java
@@ -1,0 +1,59 @@
+package co.com.pragma.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObjectMapperConfigTest {
+
+    private ObjectMapperConfig objectMapperConfig;
+
+    @BeforeEach
+    void setUp() {
+        objectMapperConfig = new ObjectMapperConfig();
+    }
+
+    @Test
+    @DisplayName("Should create ObjectMapper with WRITE_DATES_AS_TIMESTAMPS disabled")
+    void shouldCreateObjectMapperWithDatesAsTimestampsDisabled() {
+        // Act
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper(new Jackson2ObjectMapperBuilder());
+
+        // Assert
+        assertNotNull(objectMapper);
+        assertFalse(objectMapper.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
+    }
+
+    @Test
+    @DisplayName("Should serialize LocalDateTime as ISO-8601 string")
+    void shouldSerializeLocalDateTimeAsISOString() throws JsonProcessingException {
+        // Arrange
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper(new Jackson2ObjectMapperBuilder());
+        LocalDateTime testDate = LocalDateTime.of(2024, Month.JULY, 26, 10, 30, 0);
+        TestDto dto = new TestDto(testDate);
+        String expectedJson = "{\"date\":\"2024-07-26T10:30:00\"}";
+
+        // Act
+        String actualJson = objectMapper.writeValueAsString(dto);
+
+        // Assert
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class TestDto {
+        private final LocalDateTime date;
+    }
+}

--- a/applications/app-service/src/test/java/co/com/pragma/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/pragma/config/UseCasesConfigTest.java
@@ -1,5 +1,6 @@
 package co.com.pragma.config;
 
+import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.model.loantype.gateways.LoanTypeRepository;
 import co.com.pragma.model.logs.gateways.LoggerPort;
 import co.com.pragma.model.solicitude.gateways.SolicitudeRepository;
@@ -77,6 +78,11 @@ class UseCasesConfigTest {
         @Bean
         public TemplatePort templatePort(){
             return Mockito.mock(TemplatePort.class);
+        }
+
+        @Bean
+        public JwtProviderPort jwtPort(){
+            return Mockito.mock(JwtProviderPort.class);
         }
     }
 }

--- a/domain/model/src/main/java/co/com/pragma/model/constants/Errors.java
+++ b/domain/model/src/main/java/co/com/pragma/model/constants/Errors.java
@@ -59,4 +59,12 @@ public class Errors {
     public static final String USER_GATEWAY_ERROR_FROM_SERVICE = "Error from user service";
     public static final String USER_GATEWAY_ERROR_FROM_SERVICE_CODE = "GW-001";
 
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class QueueError{
+        public static final String ALIAS_EMPTY = "Queue not set.";
+        public static final String ALIAS_EMPTY_CODE = "Q001";
+        public static final String NOT_FOUND = "Queue not found.";
+        public static final String NOT_FOUND_CODE = "Q002";
+    }
+
 }

--- a/domain/model/src/main/java/co/com/pragma/model/exceptions/UserNotFoundException.java
+++ b/domain/model/src/main/java/co/com/pragma/model/exceptions/UserNotFoundException.java
@@ -1,7 +1,10 @@
 package co.com.pragma.model.exceptions;
 
+import static co.com.pragma.model.constants.Errors.USER_NOT_FOUND;
+import static co.com.pragma.model.constants.Errors.USER_NOT_FOUND_CODE;
+
 public class UserNotFoundException extends CustomException {
-    public UserNotFoundException(String message, String code) {
-        super(message, code);
+    public UserNotFoundException(String email) {
+        super(USER_NOT_FOUND + " Email: " + email, USER_NOT_FOUND_CODE);
     }
 }

--- a/domain/model/src/main/java/co/com/pragma/model/jwt/gateways/JwtProviderPort.java
+++ b/domain/model/src/main/java/co/com/pragma/model/jwt/gateways/JwtProviderPort.java
@@ -4,5 +4,6 @@ import co.com.pragma.model.jwt.JwtData;
 
 public interface JwtProviderPort {
 
+    String generateCallbackToken(String taskId);
     JwtData getClaims(String token);
 }

--- a/domain/model/src/main/java/co/com/pragma/model/solicitude/gateways/SolicitudeRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/model/solicitude/gateways/SolicitudeRepository.java
@@ -6,10 +6,14 @@ import co.com.pragma.model.solicitude.reports.SolicitudeReportFilter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 public interface SolicitudeRepository {
     Mono<Solicitude> save(Solicitude solicitudeResponse);
 
     Flux<SolicitudeReport> findSolicitudeReport(SolicitudeReportFilter filter);
+
+    Mono<BigDecimal> findTotalMonthlyFee(String email);
 
     Mono<Long> countSolicitudeReport(SolicitudeReportFilter filter);
 

--- a/domain/model/src/main/java/co/com/pragma/model/solicitude/gateways/SolicitudeRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/model/solicitude/gateways/SolicitudeRepository.java
@@ -18,4 +18,6 @@ public interface SolicitudeRepository {
     Mono<Long> countSolicitudeReport(SolicitudeReportFilter filter);
 
     Mono<Solicitude> findById(Integer solicitudeId);
+
+    Flux<Solicitude> findByEmail(String email);
 }

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
@@ -11,12 +11,10 @@ import java.math.BigDecimal;
 @Builder(toBuilder = true)
 public class DebtCapacity {
     private Integer solicitudeId;
-    private String email;
     private BigDecimal baseSalary;
     private BigDecimal value;
     private BigDecimal interestRate;
     private Integer deadline;
     private BigDecimal currentTotalMonthlyFee;
-    private Integer deadline;
     private String token;
 }

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
@@ -1,0 +1,18 @@
+package co.com.pragma.model.sqs;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+public class DebtCapacity {
+    private Integer solicitudeId;
+    private BigDecimal baseSalary;
+    private BigDecimal value;
+    private BigDecimal interestRate;
+    private BigDecimal currentTotalMonthlyFee;
+}

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/DebtCapacity.java
@@ -15,4 +15,6 @@ public class DebtCapacity {
     private BigDecimal value;
     private BigDecimal interestRate;
     private BigDecimal currentTotalMonthlyFee;
+    private Integer deadline;
+    private String token;
 }

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/exceptions/QueueAliasEmptyException.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/exceptions/QueueAliasEmptyException.java
@@ -1,0 +1,10 @@
+package co.com.pragma.model.sqs.exceptions;
+
+import co.com.pragma.model.constants.Errors.QueueError;
+import co.com.pragma.model.exceptions.CustomException;
+
+public class QueueAliasEmptyException extends CustomException {
+    public QueueAliasEmptyException() {
+        super(QueueError.ALIAS_EMPTY, QueueError.ALIAS_EMPTY_CODE);
+    }
+}

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/exceptions/QueueNotFoundException.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/exceptions/QueueNotFoundException.java
@@ -1,0 +1,10 @@
+package co.com.pragma.model.sqs.exceptions;
+
+import co.com.pragma.model.constants.Errors.QueueError;
+import co.com.pragma.model.exceptions.CustomException;
+
+public class QueueNotFoundException extends CustomException {
+    public QueueNotFoundException() {
+        super(QueueError.NOT_FOUND, QueueError.NOT_FOUND_CODE);
+    }
+}

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/gateways/SQSPort.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/gateways/SQSPort.java
@@ -1,5 +1,9 @@
 package co.com.pragma.model.sqs.gateways;
 
+import co.com.pragma.model.sqs.DebtCapacity;
+import reactor.core.publisher.Mono;
+
 public interface SQSPort {
-    void sendEmail(String email, String title, String message);
+    Mono<Void> sendEmail(String email, String title, String message);
+    Mono<Void> sendDebtCapacity(DebtCapacity debtCapacity);
 }

--- a/domain/model/src/main/java/co/com/pragma/model/sqs/gateways/SQSPort.java
+++ b/domain/model/src/main/java/co/com/pragma/model/sqs/gateways/SQSPort.java
@@ -1,9 +1,12 @@
 package co.com.pragma.model.sqs.gateways;
 
 import co.com.pragma.model.sqs.DebtCapacity;
+import co.com.pragma.model.template.EmailMessage;
 import reactor.core.publisher.Mono;
 
 public interface SQSPort {
-    Mono<Void> sendEmail(String email, String title, String message);
+
+    Mono<Void> sendEmail(EmailMessage emailMessage);
+
     Mono<Void> sendDebtCapacity(DebtCapacity debtCapacity);
 }

--- a/domain/model/src/main/java/co/com/pragma/model/template/EmailMessage.java
+++ b/domain/model/src/main/java/co/com/pragma/model/template/EmailMessage.java
@@ -1,0 +1,14 @@
+package co.com.pragma.model.template;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+public class EmailMessage {
+    private String to;
+    private String subject;
+    private String body;
+}

--- a/domain/model/src/main/java/co/com/pragma/model/template/EmailTemplate.java
+++ b/domain/model/src/main/java/co/com/pragma/model/template/EmailTemplate.java
@@ -1,9 +1,16 @@
 package co.com.pragma.model.template;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+public enum EmailTemplate {
+    STATE_CHANGE("state-change-notification"),
+    PAY_PLAN("pay-plan-notification");
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class EmailTemplate {
-    public static final String STATE_CHANGE = "state-change-notification";
+    private final String templateName;
+
+    EmailTemplate(String templateName) {
+        this.templateName = templateName;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
 }

--- a/domain/model/src/main/java/co/com/pragma/model/template/Installment.java
+++ b/domain/model/src/main/java/co/com/pragma/model/template/Installment.java
@@ -1,0 +1,8 @@
+package co.com.pragma.model.template;
+
+public record Installment(
+        int month,
+        String principal,
+        String interest,
+        String remainingBalance
+) {}

--- a/domain/model/src/main/java/co/com/pragma/model/template/gateways/TemplatePort.java
+++ b/domain/model/src/main/java/co/com/pragma/model/template/gateways/TemplatePort.java
@@ -1,7 +1,9 @@
 package co.com.pragma.model.template.gateways;
 
+import reactor.core.publisher.Mono;
+
 import java.util.Map;
 
 public interface TemplatePort {
-    String process(String templateName, Map<String, Object> context);
+    Mono<String> process(String templateName, Map<String, Object> context);
 }

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/NotificationUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/NotificationUtils.java
@@ -30,8 +30,12 @@ public class NotificationUtils {
     }
 
     public static Map<String, Object> userPayPlan(Solicitude solicitude) {
+        Objects.requireNonNull(solicitude, "Solicitude cannot be null for generating a pay plan.");
+        Objects.requireNonNull(solicitude.getValue(), "Solicitude value (principal) cannot be null.");
+        Objects.requireNonNull(solicitude.getLoanType(), "Solicitude loan type cannot be null.");
+        Objects.requireNonNull(solicitude.getLoanType().getInterestRate(), "Solicitude interest rate cannot be null.");
+
         BigDecimal principal = solicitude.getValue();
-        double annualInterestRate = solicitude.getLoanType().getInterestRate().multiply(new BigDecimal(12)).doubleValue();
         int termInMonths = solicitude.getDeadline();
 
         double monthlyInterestRate = solicitude.getLoanType().getInterestRate().doubleValue() / 100;
@@ -51,7 +55,6 @@ public class NotificationUtils {
                 principalPaid = principalPaid.add(remainingBalance);
                 remainingBalance = BigDecimal.ZERO;
             }
-
             installments.add(new Installment(
                     month,
                     formatCurrency(principalPaid),
@@ -63,7 +66,7 @@ public class NotificationUtils {
         Map<String, Object> context = new HashMap<>();
         context.put("solicitudeId", solicitude.getSolicitudeId());
         context.put("loanValue", formatCurrency(principal));
-        context.put("interestRate", String.format("%.2f%%", annualInterestRate));
+        context.put("interestRate", String.format("%.2f%%", solicitude.getLoanType().getInterestRate().doubleValue()));
         context.put("deadline", termInMonths);
         context.put("monthlyPayment", formatCurrency(monthlyPayment));
         context.put("totalInterest", formatCurrency(totalInterest));

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/NotificationUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/NotificationUtils.java
@@ -47,14 +47,17 @@ public class NotificationUtils {
 
         for (int month = 1; month <= termInMonths; month++) {
             BigDecimal interestPaid = remainingBalance.multiply(BigDecimal.valueOf(monthlyInterestRate)).setScale(2, RoundingMode.HALF_UP);
-            BigDecimal principalPaid = monthlyPayment.subtract(interestPaid);
+            BigDecimal principalPaid;
+
+            if (month == termInMonths) {
+                principalPaid = remainingBalance;
+            } else {
+                principalPaid = monthlyPayment.subtract(interestPaid);
+            }
+
             remainingBalance = remainingBalance.subtract(principalPaid);
             totalInterest = totalInterest.add(interestPaid);
 
-            if (month == termInMonths && remainingBalance.abs().compareTo(BigDecimal.valueOf(0.01)) < 0) {
-                principalPaid = principalPaid.add(remainingBalance);
-                remainingBalance = BigDecimal.ZERO;
-            }
             installments.add(new Installment(
                     month,
                     formatCurrency(principalPaid),

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/SolicitudeUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/SolicitudeUtils.java
@@ -3,6 +3,7 @@ package co.com.pragma.usecase.solicitude.utils;
 import co.com.pragma.model.constants.DefaultValues;
 import co.com.pragma.model.exceptions.*;
 import co.com.pragma.model.jwt.JwtData;
+import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.model.loantype.LoanType;
 import co.com.pragma.model.loantype.exceptions.LoanTypeValueErrorException;
 import co.com.pragma.model.solicitude.Solicitude;
@@ -92,22 +93,26 @@ public class SolicitudeUtils {
         return Mono.error(new InvalidCredentialsException());
     }
 
-    public static Mono<Void> validateApproveRejectRequestedData(Integer solicitudeId, String state){
+    public static Mono<Void> validateApproveRejectRequestedData(Integer solicitudeId, String state, boolean acceptsManual) {
         if (solicitudeId == null) return Mono.error(new SolicitudeNullException());
         if (state == null) return Mono.error(new StateNotFoundException());
-        if (!state.equals(DefaultValues.APPROVED_STATE) &&
-                !state.equals(DefaultValues.REJECTED_STATE))
+        if (!(state.equals(DefaultValues.APPROVED_STATE) ||
+                state.equals(DefaultValues.REJECTED_STATE) ||
+                (acceptsManual && state.equals(DefaultValues.MANUAL_STATE)))
+        )
             return Mono.error(new InvalidFieldException(DefaultValues.STATE_FIELD));
         return Mono.empty();
     }
 
-    public static DebtCapacity buildDebtCapacity(UserProjection user,Solicitude solicitude,BigDecimal totalFee){
+    public static DebtCapacity buildDebtCapacity(UserProjection user, Solicitude solicitude, BigDecimal totalFee, JwtProviderPort jwtPort) {
         return DebtCapacity.builder()
                 .solicitudeId(solicitude.getSolicitudeId())
                 .baseSalary(user.getBaseSalary())
                 .value(solicitude.getValue())
                 .interestRate(solicitude.getLoanType().getInterestRate())
                 .currentTotalMonthlyFee(totalFee)
+                .deadline(solicitude.getDeadline())
+                .token(jwtPort.generateCallbackToken(solicitude.getSolicitudeId().toString()))
                 .build();
     }
 }

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/SolicitudeUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/solicitude/utils/SolicitudeUtils.java
@@ -7,7 +7,9 @@ import co.com.pragma.model.loantype.LoanType;
 import co.com.pragma.model.loantype.exceptions.LoanTypeValueErrorException;
 import co.com.pragma.model.solicitude.Solicitude;
 import co.com.pragma.model.solicitude.exceptions.SolicitudeNullException;
+import co.com.pragma.model.sqs.DebtCapacity;
 import co.com.pragma.model.state.exceptions.StateNotFoundException;
+import co.com.pragma.model.user.UserProjection;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import reactor.core.publisher.Mono;
@@ -97,5 +99,15 @@ public class SolicitudeUtils {
                 !state.equals(DefaultValues.REJECTED_STATE))
             return Mono.error(new InvalidFieldException(DefaultValues.STATE_FIELD));
         return Mono.empty();
+    }
+
+    public static DebtCapacity buildDebtCapacity(UserProjection user,Solicitude solicitude,BigDecimal totalFee){
+        return DebtCapacity.builder()
+                .solicitudeId(solicitude.getSolicitudeId())
+                .baseSalary(user.getBaseSalary())
+                .value(solicitude.getValue())
+                .interestRate(solicitude.getLoanType().getInterestRate())
+                .currentTotalMonthlyFee(totalFee)
+                .build();
     }
 }

--- a/domain/usecase/src/test/java/co/com/pragma/usecase/loantype/LoanTypeUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/usecase/loantype/LoanTypeUseCaseTest.java
@@ -1,0 +1,73 @@
+package co.com.pragma.usecase.loantype;
+
+import co.com.pragma.model.loantype.LoanType;
+import co.com.pragma.model.loantype.gateways.LoanTypeRepository;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LoanTypeUseCaseTest {
+
+    /**
+     * Unit tests for the getAllLoanTypes method in LoanTypeUseCase.
+     * This method is responsible for retrieving all loan types from the repository.
+     */
+
+    @Test
+    void getAllLoanTypes_shouldReturnLoanTypes_whenRepositoryReturnsLoanTypes() {
+        // Arrange
+        LoanTypeRepository loanTypeRepository = mock(LoanTypeRepository.class);
+        LoanTypeUseCase loanTypeUseCase = new LoanTypeUseCase(loanTypeRepository);
+
+        LoanType loanType1 = LoanType.builder().build();
+        LoanType loanType2 = LoanType.builder().build();
+        when(loanTypeRepository.findAll()).thenReturn(Flux.just(loanType1, loanType2));
+
+        // Act
+        Flux<LoanType> result = loanTypeUseCase.getAllLoanTypes();
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNext(loanType1)
+                .expectNext(loanType2)
+                .verifyComplete();
+    }
+
+    @Test
+    void getAllLoanTypes_shouldReturnEmpty_whenRepositoryReturnsEmpty() {
+        // Arrange
+        LoanTypeRepository loanTypeRepository = mock(LoanTypeRepository.class);
+        LoanTypeUseCase loanTypeUseCase = new LoanTypeUseCase(loanTypeRepository);
+
+        when(loanTypeRepository.findAll()).thenReturn(Flux.empty());
+
+        // Act
+        Flux<LoanType> result = loanTypeUseCase.getAllLoanTypes();
+
+        // Assert
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void getAllLoanTypes_shouldError_whenRepositoryErrors() {
+        // Arrange
+        LoanTypeRepository loanTypeRepository = mock(LoanTypeRepository.class);
+        LoanTypeUseCase loanTypeUseCase = new LoanTypeUseCase(loanTypeRepository);
+
+        RuntimeException exception = new RuntimeException("Database error");
+        when(loanTypeRepository.findAll()).thenReturn(Flux.error(exception));
+
+        // Act
+        Flux<LoanType> result = loanTypeUseCase.getAllLoanTypes();
+
+        // Assert
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof RuntimeException
+                        && throwable.getMessage().equals("Database error"))
+                .verify();
+    }
+}

--- a/domain/usecase/src/test/java/co/com/pragma/usecase/solicitude/SolicitudeUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/usecase/solicitude/SolicitudeUseCaseTest.java
@@ -115,7 +115,6 @@ class SolicitudeUseCaseTest {
         });
         when(userPort.getUserByEmail(anyString())).thenReturn(Mono.just(mockUser));
         when(solicitudeRepository.findTotalMonthlyFee(anyString())).thenReturn(Mono.just(BigDecimal.ZERO));
-        when(sqsPort.sendDebtCapacity(any())).thenReturn(Mono.empty());
 
         StepVerifier.create(solicitudeUseCase.saveSolicitude(testSolicitude, "12345", testJwtData))
                 .expectNextMatches(result ->

--- a/domain/usecase/src/test/java/co/com/pragma/usecase/solicitude/utils/NotificationUtilsTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/usecase/solicitude/utils/NotificationUtilsTest.java
@@ -1,0 +1,167 @@
+package co.com.pragma.usecase.solicitude.utils;
+
+import co.com.pragma.model.constants.DefaultValues;
+import co.com.pragma.model.loantype.LoanType;
+import co.com.pragma.model.solicitude.Solicitude;
+import co.com.pragma.model.state.State;
+import co.com.pragma.model.template.Installment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotificationUtilsTest {
+
+    private String formatCurrencyForTest(BigDecimal value) {
+        if (value == null) return "N/A";
+        NumberFormat currencyFormatter = NumberFormat.getCurrencyInstance(new Locale("es", "CO"));
+        return currencyFormatter.format(value);
+    }
+
+    @Nested
+    @DisplayName("solicitudeChangeStateBody Tests")
+    class SolicitudeChangeStateBodyTests {
+
+        @Test
+        @DisplayName("Should create context map for state change notification")
+        void shouldCreateContextMapForStateChange() {
+            // Arrange
+            LoanType loanType = LoanType.builder().name("Personal Loan").build();
+            State state = State.builder().name(DefaultValues.APPROVED_STATE).description("Your loan is approved").build();
+            Solicitude solicitude = Solicitude.builder()
+                    .solicitudeId(123)
+                    .loanType(loanType)
+                    .value(new BigDecimal("10000"))
+                    .state(state)
+                    .build();
+
+            // Act
+            Map<String, Object> context = NotificationUtils.solicitudeChangeStateBody(solicitude);
+
+            // Assert
+            assertAll(
+                    () -> assertEquals(123, context.get("solicitudeId")),
+                    () -> assertEquals("Personal Loan", context.get("loanType")),
+                    () -> assertEquals(formatCurrencyForTest(new BigDecimal("10000")), context.get("value")),
+                    () -> assertEquals(DefaultValues.APPROVED_STATE, context.get("stateName")),
+                    () -> assertEquals("Your loan is approved", context.get("stateDescription")),
+                    () -> assertEquals("approved", context.get("stateClass"))
+            );
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "APROBADO, approved",
+                "RECHAZADO, rejected",
+                "MANUAL, manual",
+                "PENDIENTE, pending",
+                "SOME_OTHER_STATE, pending"
+        })
+        @DisplayName("Should return correct state class for different state names")
+        void shouldReturnCorrectStateClass(String stateName, String expectedClass) {
+            // Arrange
+            State state = State.builder().name(stateName).build();
+            Solicitude solicitude = Solicitude.builder()
+                    .solicitudeId(1)
+                    .loanType(LoanType.builder().name("Test").build())
+                    .value(BigDecimal.ONE)
+                    .state(state)
+                    .build();
+
+            // Act
+            Map<String, Object> context = NotificationUtils.solicitudeChangeStateBody(solicitude);
+
+            // Assert
+            assertEquals(expectedClass, context.get("stateClass"));
+        }
+    }
+
+    @Nested
+    @DisplayName("userPayPlan Tests")
+    class UserPayPlanTests {
+
+        @Test
+        @DisplayName("Should generate correct pay plan for a standard loan")
+        void shouldGenerateCorrectPayPlan() {
+            // Arrange
+            LoanType loanType = LoanType.builder().interestRate(new BigDecimal("2")).build();
+            Solicitude solicitude = Solicitude.builder()
+                    .solicitudeId(456)
+                    .value(new BigDecimal("1000"))
+                    .deadline(3)
+                    .loanType(loanType)
+                    .build();
+
+            // Act
+            Map<String, Object> context = NotificationUtils.userPayPlan(solicitude);
+
+            // Assert
+            assertEquals(456, context.get("solicitudeId"));
+            assertEquals(formatCurrencyForTest(new BigDecimal("1000")), context.get("loanValue"));
+            assertEquals("2.00%", context.get("interestRate"));
+            assertEquals(3, context.get("deadline"));
+            assertEquals(formatCurrencyForTest(new BigDecimal("346.75")), context.get("monthlyPayment"));
+
+            @SuppressWarnings("unchecked")
+            List<Installment> installments = (List<Installment>) context.get("installments");
+            assertNotNull(installments);
+            assertEquals(3, installments.size());
+
+            // Check first installment
+            Installment first = installments.get(0);
+            assertEquals(1, first.month());
+            assertEquals(formatCurrencyForTest(new BigDecimal("326.75")), first.principal()); // 346.75 - 20 (2% of 1000)
+            assertEquals(formatCurrencyForTest(new BigDecimal("20.00")), first.interest());
+            assertEquals(formatCurrencyForTest(new BigDecimal("673.25")), first.remainingBalance()); // 1000 - 326.75
+
+            // Check last installment
+            Installment last = installments.get(2);
+            assertEquals(3, last.month());
+            assertEquals(formatCurrencyForTest(BigDecimal.ZERO), last.remainingBalance());
+        }
+
+        @Test
+        @DisplayName("Should generate correct pay plan for a zero interest loan")
+        void shouldGenerateCorrectPayPlanForZeroInterest() {
+            // Arrange
+            LoanType loanType = LoanType.builder().interestRate(BigDecimal.ZERO).build();
+            Solicitude solicitude = Solicitude.builder()
+                    .solicitudeId(789)
+                    .value(new BigDecimal("1200"))
+                    .deadline(4)
+                    .loanType(loanType)
+                    .build();
+
+            // Act
+            Map<String, Object> context = NotificationUtils.userPayPlan(solicitude);
+
+            // Assert
+            assertEquals(formatCurrencyForTest(new BigDecimal("300")), context.get("monthlyPayment"));
+            assertEquals(formatCurrencyForTest(BigDecimal.ZERO), context.get("totalInterest"));
+        }
+
+        @Test
+        @DisplayName("Should throw NullPointerException for missing required data")
+        void shouldThrowExceptionForMissingData() {
+            assertThrows(NullPointerException.class, () -> NotificationUtils.userPayPlan(null));
+
+            Solicitude s1 = Solicitude.builder().value(null).build();
+            assertThrows(NullPointerException.class, () -> NotificationUtils.userPayPlan(s1));
+
+            Solicitude s2 = Solicitude.builder().value(BigDecimal.ONE).loanType(null).build();
+            assertThrows(NullPointerException.class, () -> NotificationUtils.userPayPlan(s2));
+
+            Solicitude s3 = Solicitude.builder().value(BigDecimal.ONE).loanType(LoanType.builder().interestRate(null).build()).build();
+            assertThrows(NullPointerException.class, () -> NotificationUtils.userPayPlan(s3));
+        }
+    }
+}

--- a/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/JwtProviderAdapter.java
@@ -5,6 +5,7 @@ import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Base64;
+import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +21,19 @@ import java.util.Base64;
 public class JwtProviderAdapter implements JwtProviderPort {
 
     private final JwtProperties jwtProperties;
+
+    @Override
+    public String generateCallbackToken(String taskId) {
+        long now = System.currentTimeMillis();
+        long expirationTime = now + (15 * 60 * 1000);//15 minutes
+        return Jwts.builder()
+                .setSubject(taskId)
+                .claim("role", "CALLBACK_ROLE")
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(expirationTime))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
 
     @Override
     public JwtData getClaims(String token) {

--- a/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/mustachetemplate/MustacheTemplateAdapter.java
+++ b/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/mustachetemplate/MustacheTemplateAdapter.java
@@ -5,6 +5,8 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.StringWriter;
 import java.util.Map;
@@ -15,11 +17,13 @@ public class MustacheTemplateAdapter implements TemplatePort {
     private final MustacheFactory mf = new DefaultMustacheFactory("templates");
 
     @Override
-    public String process(String templateName, Map<String, Object> context) {
-        Mustache mustache = mf.compile(templateName + ".mustache");
-        StringWriter writer = new StringWriter();
-        mustache.execute(writer, context);
-        return writer.toString();
+    public Mono<String> process(String templateName, Map<String, Object> context) {
+        return Mono.fromCallable(() -> {
+            Mustache mustache = this.mf.compile(templateName + ".mustache");
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context).flush();
+            return writer.toString();
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
 }

--- a/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/pay-plan-notification.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/pay-plan-notification.mustache
@@ -37,7 +37,7 @@
                     <td>{{loanValue}}</td>
                 </tr>
                 <tr>
-                    <td>Annual Interest Rate:</td>
+                    <td>Interest Rate:</td>
                     <td>{{interestRate}}</td>
                 </tr>
                 <tr>

--- a/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/pay-plan-notification.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/pay-plan-notification.mustache
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Loan Payment Plan</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { width: 90%; max-width: 600px; margin: 20px auto; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; }
+        .header { background-color: #0056b3; color: #ffffff; padding: 20px; text-align: center; }
+        .header h1 { margin: 0; }
+        .content { padding: 30px; }
+        .content p { margin-bottom: 20px; }
+        .content h3 { margin-top: 30px; }
+        .summary-table, .plan-table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
+        .summary-table td { padding: 8px; border: 1px solid #ddd; }
+        .summary-table td:first-child { font-weight: bold; }
+        .plan-table th, .plan-table td { border: 1px solid #ddd; padding: 8px; text-align: right; }
+        .plan-table th { background-color: #f2f2f2; text-align: center; }
+        .footer { background-color: #f8f9fa; padding: 20px; text-align: center; font-size: 0.9em; color: #6c757d; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>CrediYa</h1>
+        </div>
+        <div class="content">
+            <h2>Your loan application has been approved!</h2>
+            <p>Hello,</p>
+            <p>We are pleased to inform you that your loan application with ID <strong>{{solicitudeId}}</strong> has been approved. Below you will find the summary and detailed payment plan.</p>
+
+            <h3>Loan Summary</h3>
+            <table class="summary-table">
+                <tr>
+                    <td>Loan Amount:</td>
+                    <td>{{loanValue}}</td>
+                </tr>
+                <tr>
+                    <td>Annual Interest Rate:</td>
+                    <td>{{interestRate}}</td>
+                </tr>
+                <tr>
+                    <td>Term:</td>
+                    <td>{{deadline}} months</td>
+                </tr>
+                <tr>
+                    <td><strong>Fixed Monthly Payment:</strong></td>
+                    <td><strong>{{monthlyPayment}}</strong></td>
+                </tr>
+                <tr>
+                    <td>Total Interest to be Paid:</td>
+                    <td>{{totalInterest}}</td>
+                </tr>
+                <tr>
+                    <td>Total Payment (Principal + Interest):</td>
+                    <td>{{totalPayment}}</td>
+                </tr>
+            </table>
+
+            <h3>Detailed Payment Plan</h3>
+            <table class="plan-table">
+                <thead>
+                    <tr>
+                        <th>Month</th>
+                        <th>Principal Payment</th>
+                        <th>Interest Payment</th>
+                        <th>Remaining Balance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#installments}}
+                    <tr>
+                        <td style="text-align: center;">{{month}}</td>
+                        <td>{{principal}}</td>
+                        <td>{{interest}}</td>
+                        <td>{{remainingBalance}}</td>
+                    </tr>
+                    {{/installments}}
+                </tbody>
+            </table>
+            <p>If you have any questions, please do not hesitate to contact us.</p>
+            <p>Sincerely,<br>The CrediYa Team</p>
+        </div>
+        <div class="footer">
+            &copy; 2025 CrediYa. All rights reserved.
+        </div>
+    </div>
+</body>
+</html>

--- a/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/state-change-notification.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/state-change-notification.mustache
@@ -14,6 +14,7 @@
         .status-box { padding: 15px; border-radius: 5px; text-align: center; font-weight: bold; font-size: 1.2em; }
         .approved { background-color: #d4edda; color: #155724; }
         .rejected { background-color: #f8d7da; color: #721c24; }
+        .manual { background-color: #cce5ff; color: #004085; }
         .pending { background-color: #fff3cd; color: #856404; }
         .footer { background-color: #f8f9fa; padding: 20px; text-align: center; font-size: 0.9em; color: #6c757d; }
     </style>

--- a/infrastructure/driven-adapters/mustache-template/src/test/java/co/com/pragma/mustachetemplate/MustacheTemplateAdapterTest.java
+++ b/infrastructure/driven-adapters/mustache-template/src/test/java/co/com/pragma/mustachetemplate/MustacheTemplateAdapterTest.java
@@ -4,11 +4,10 @@ import com.github.mustachejava.MustacheException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MustacheTemplateAdapterTest {
 
@@ -33,23 +32,28 @@ class MustacheTemplateAdapterTest {
         String expectedOutput = "Hello, Juan! Your loan for $10,000 has been approved.";
 
         // Act
-        String result = mustacheTemplateAdapter.process(templateName, context);
+        Mono<String> result = mustacheTemplateAdapter.process(templateName, context);
 
         // Assert
-        assertEquals(expectedOutput, result);
+        StepVerifier.create(result)
+                .expectNext(expectedOutput)
+                .verifyComplete();
     }
 
     @Test
-    @DisplayName("Should throw MustacheException when template file does not exist")
-    void process_shouldThrowExceptionForNonExistentTemplate() {
+    @DisplayName("Should return a Mono error when template file does not exist")
+    void process_shouldReturnMonoErrorForNonExistentTemplate() {
         // Arrange
         String templateName = "non-existent-template";
         Map<String, Object> context = Map.of();
 
-        // Act & Assert
-        // Se verifica que se lance la excepción esperada cuando la plantilla no se encuentra.
-        assertThrows(MustacheException.class, () -> {
-            mustacheTemplateAdapter.process(templateName, context);
-        });
+        // Act
+        Mono<String> result = mustacheTemplateAdapter.process(templateName, context);
+
+        // Assert
+        // StepVerifier se suscribe al Mono y verifica que termine con la señal de error esperada.
+        StepVerifier.create(result)
+                .expectError(MustacheException.class)
+                .verify();
     }
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepository.java
@@ -4,9 +4,12 @@ import co.com.pragma.r2dbc.entity.SolicitudeEntity;
 import co.com.pragma.r2dbc.reports.SolicitudeEntityRepositoryCustom;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 public interface SolicitudeEntityRepository extends
         ReactiveCrudRepository<SolicitudeEntity, Integer>,
         ReactiveQueryByExampleExecutor<SolicitudeEntity>,
         SolicitudeEntityRepositoryCustom {
+
+    Flux<SolicitudeEntity> findByEmail(String email);
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepositoryAdapter.java
@@ -46,4 +46,9 @@ public class SolicitudeEntityRepositoryAdapter implements SolicitudeRepository {
     public Mono<Solicitude> findById(Integer solicitudeId) {
         return solicitudeRepository.findById(solicitudeId).map(solicitudeMapper::toDomain);
     }
+
+    @Override
+    public Flux<Solicitude> findByEmail(String email) {
+        return solicitudeRepository.findByEmail(email).map(solicitudeMapper::toDomain);
+    }
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/SolicitudeEntityRepositoryAdapter.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 @Repository
 @RequiredArgsConstructor
 public class SolicitudeEntityRepositoryAdapter implements SolicitudeRepository {
@@ -28,6 +30,11 @@ public class SolicitudeEntityRepositoryAdapter implements SolicitudeRepository {
     @Override
     public Flux<SolicitudeReport> findSolicitudeReport(SolicitudeReportFilter filter) {
         return solicitudeRepository.findSolicitudeReport(filter);
+    }
+
+    @Override
+    public Mono<BigDecimal> findTotalMonthlyFee(String email) {
+        return solicitudeRepository.findTotalMonthlyFee(email);
     }
 
     @Override

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryCustom.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryCustom.java
@@ -5,8 +5,12 @@ import co.com.pragma.model.solicitude.reports.SolicitudeReportFilter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.math.BigDecimal;
+
 public interface SolicitudeEntityRepositoryCustom {
     Flux<SolicitudeReport> findSolicitudeReport(SolicitudeReportFilter filter);
 
     Mono<Long> countSolicitudeReport(SolicitudeReportFilter filter);
+
+    Mono<BigDecimal> findTotalMonthlyFee(String email);
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryImpl.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryImpl.java
@@ -74,4 +74,22 @@ public class SolicitudeEntityRepositoryImpl implements SolicitudeEntityRepositor
         }
         return executeSpec.map(row -> row.get(0, Long.class)).one().defaultIfEmpty(0L);
     }
+
+    @Override
+    public Mono<BigDecimal> findTotalMonthlyFee(String email) {
+        String sql = """
+                SELECT COALESCE(SUM(
+                   sx.monto *
+                   ( (tpx.tasa_interes/100) * POWER(1 + (tpx.tasa_interes/100), sx.plazo) ) /
+                   ( POWER(1 + (tpx.tasa_interes/100), sx.plazo ) - 1 )
+                ), 0)
+                FROM solicitud sx
+                JOIN tipo_prestamo tpx ON tpx.id_tipo_prestamo = sx.id_tipo_prestamo
+                JOIN estados ex ON ex.id_estado = sx.id_estado
+                WHERE sx.email = :email
+                """;
+        DatabaseClient.GenericExecuteSpec executeSpec = databaseClient.sql(sql)
+                .bind("email",email);
+        return executeSpec.map(row -> row.get(0, BigDecimal.class)).one().defaultIfEmpty(BigDecimal.ZERO);
+    }
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryImpl.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/pragma/r2dbc/reports/SolicitudeEntityRepositoryImpl.java
@@ -86,7 +86,7 @@ public class SolicitudeEntityRepositoryImpl implements SolicitudeEntityRepositor
                 FROM solicitud sx
                 JOIN tipo_prestamo tpx ON tpx.id_tipo_prestamo = sx.id_tipo_prestamo
                 JOIN estados ex ON ex.id_estado = sx.id_estado
-                WHERE sx.email = :email
+                WHERE sx.email = :email and ex.nombre = 'APROBADO'
                 """;
         DatabaseClient.GenericExecuteSpec executeSpec = databaseClient.sql(sql)
                 .bind("email",email);

--- a/infrastructure/driven-adapters/sqs-sender/build.gradle
+++ b/infrastructure/driven-adapters/sqs-sender/build.gradle
@@ -7,4 +7,8 @@ dependencies {
     //ObjectMapper
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+    //Mapstruct
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/SQSSender.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/SQSSender.java
@@ -1,8 +1,13 @@
 package co.com.pragma.sqs.sender;
 
+import co.com.pragma.model.sqs.DebtCapacity;
+import co.com.pragma.model.sqs.exceptions.QueueAliasEmptyException;
+import co.com.pragma.model.sqs.exceptions.QueueNotFoundException;
 import co.com.pragma.model.sqs.gateways.SQSPort;
+import co.com.pragma.sqs.sender.config.QueueAlias;
 import co.com.pragma.sqs.sender.config.SQSSenderProperties;
 import co.com.pragma.sqs.sender.dto.EmailSqsMessage;
+import co.com.pragma.sqs.sender.mapper.DebtCapacityMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -20,39 +25,56 @@ public class SQSSender implements SQSPort {
     private final SQSSenderProperties properties;
     private final SqsAsyncClient client;
     private final ObjectMapper objectMapper;
+    private final DebtCapacityMapper debtCapacityMapper;
 
-    public Mono<String> send(String message) {
-        return Mono.fromCallable(() -> buildRequest(message))
+    public Mono<String> send(String queueAlias, String message) {
+        return Mono.justOrEmpty(queueAlias)
+                .switchIfEmpty(Mono.error(new QueueAliasEmptyException()))
+                .flatMap(alias -> Mono.justOrEmpty(properties.queues().get(alias)))
+                .switchIfEmpty(Mono.error(new QueueNotFoundException()))
+                .map(queueUrl -> buildRequest(queueUrl, message))
                 .flatMap(request -> Mono.fromFuture(client.sendMessage(request)))
                 .doOnNext(response -> log.debug("Message sent {}", response.messageId()))
                 .map(SendMessageResponse::messageId);
     }
 
-    private SendMessageRequest buildRequest(String message) {
+    private SendMessageRequest buildRequest(String url, String message) {
         return SendMessageRequest.builder()
-                .queueUrl(properties.queueUrl())
+                .queueUrl(url)
                 .messageBody(message)
                 .build();
     }
 
     @Override
-    public void sendEmail(String email, String title, String message) {
-        EmailSqsMessage payload = EmailSqsMessage.builder()
+    public Mono<Void> sendEmail(String email, String title, String message) {
+        var payload = EmailSqsMessage.builder()
                 .to(email)
                 .subject(title)
                 .body(message)
                 .build();
+        return sendGenericMessage(QueueAlias.NOTIFY_STATE_CHANGE, payload, "email notification for " + email);
+    }
+
+    @Override
+    public Mono<Void> sendDebtCapacity(DebtCapacity debtCapacity) {
+        var payload = debtCapacityMapper.toSqsMessage(debtCapacity);
+        return sendGenericMessage(QueueAlias.CALCULATE_DEBT_CAPACITY, payload, "debt capacity calculation");
+    }
+
+    private <T> Mono<Void> sendGenericMessage(String queueAlias, T payload, String logContext) {
         try {
             String jsonMessage = objectMapper.writeValueAsString(payload);
-            log.info("Sending email notification to SQS for recipient: [{}] : {}", email, jsonMessage);
-            this.send(jsonMessage)
-                    .subscribe(
-                            messageId -> log.info("Email notification for {} queued successfully with Message ID: {}", email, messageId),
-                            error -> log.error("Failed to send email notification to SQS for recipient: {}. Error: {}", email, error.getMessage())
-                    );
-
+            log.info("Sending {} to SQS: {}", logContext, jsonMessage);
+            return this.send(queueAlias, jsonMessage)
+                    .doOnSuccess(
+                            messageId -> log.info("Payload for {} queued successfully with Message ID: {}", logContext, messageId)
+                    )
+                    .doOnError(
+                            error -> log.error("Failed to send payload for {}. Error: {}", logContext, error.getMessage())
+                    ).then();
         } catch (JsonProcessingException e) {
-            log.error("Error creating JSON payload for email notification. Recipient: {}. Error: {}", email, e.getMessage());
+            log.error("Error creating JSON payload for {}. Error: {}", logContext, e.getMessage());
+            return Mono.error(e);
         }
     }
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/config/QueueAlias.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/config/QueueAlias.java
@@ -1,0 +1,10 @@
+package co.com.pragma.sqs.sender.config;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class QueueAlias {
+    public static final String NOTIFY_STATE_CHANGE = "state-change";
+    public static final String CALCULATE_DEBT_CAPACITY = "debt-capacity";
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/config/SQSSenderProperties.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/config/SQSSenderProperties.java
@@ -2,9 +2,11 @@ package co.com.pragma.sqs.sender.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.Map;
+
 @ConfigurationProperties(prefix = "adapters.sqs")
 public record SQSSenderProperties(
      String region,
-     String queueUrl,
+     Map<String, String> queues,
      String endpoint){
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
@@ -19,4 +19,6 @@ public class DebtCapacitySqsMessage {
     private BigDecimal interestRate;
     @JsonSerialize(using = MoneySerializer.class)
     private BigDecimal currentTotalMonthlyFee;
+    private Integer deadline;
+    private String token;
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 @Builder
 public class DebtCapacitySqsMessage {
     private Integer solicitudeId;
-    private String email;
     @JsonSerialize(using = MoneySerializer.class)
     private BigDecimal baseSalary;
     @JsonSerialize(using = MoneySerializer.class)
@@ -21,6 +20,5 @@ public class DebtCapacitySqsMessage {
     private Integer deadline;
     @JsonSerialize(using = MoneySerializer.class)
     private BigDecimal currentTotalMonthlyFee;
-    private Integer deadline;
     private String token;
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/dto/DebtCapacitySqsMessage.java
@@ -1,0 +1,22 @@
+package co.com.pragma.sqs.sender.dto;
+
+import co.com.pragma.sqs.sender.util.MoneySerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class DebtCapacitySqsMessage {
+    private Integer solicitudeId;
+    @JsonSerialize(using = MoneySerializer.class)
+    private BigDecimal baseSalary;
+    @JsonSerialize(using = MoneySerializer.class)
+    private BigDecimal value;
+    @JsonSerialize(using = MoneySerializer.class)
+    private BigDecimal interestRate;
+    @JsonSerialize(using = MoneySerializer.class)
+    private BigDecimal currentTotalMonthlyFee;
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/mapper/DebtCapacityMapper.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/mapper/DebtCapacityMapper.java
@@ -1,0 +1,11 @@
+package co.com.pragma.sqs.sender.mapper;
+
+import co.com.pragma.model.sqs.DebtCapacity;
+import co.com.pragma.sqs.sender.dto.DebtCapacitySqsMessage;
+import co.com.pragma.sqs.sender.util.MoneySerializer;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", uses = {MoneySerializer.class})
+public interface DebtCapacityMapper {
+    DebtCapacitySqsMessage toSqsMessage(DebtCapacity debtCapacity);
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/mapper/EmailMapper.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/mapper/EmailMapper.java
@@ -1,0 +1,11 @@
+package co.com.pragma.sqs.sender.mapper;
+
+import co.com.pragma.model.template.EmailMessage;
+import co.com.pragma.sqs.sender.dto.EmailSqsMessage;
+import org.mapstruct.Mapper;
+
+
+@Mapper(componentModel = "spring")
+public interface EmailMapper {
+    EmailSqsMessage toSqsMessage(EmailMessage emailMessage);
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/util/MoneySerializer.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/sqs/sender/util/MoneySerializer.java
@@ -1,0 +1,22 @@
+package co.com.pragma.sqs.sender.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class MoneySerializer extends JsonSerializer<BigDecimal> {
+
+    @Override
+    public void serialize(BigDecimal value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value == null) {
+            gen.writeNull();
+        } else {
+            BigDecimal formattedValue = value.setScale(2, RoundingMode.HALF_UP);
+            gen.writeString(formattedValue.toPlainString());
+        }
+    }
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/sqs/sender/util/MoneySerializerTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/sqs/sender/util/MoneySerializerTest.java
@@ -1,0 +1,70 @@
+package co.com.pragma.sqs.sender.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class MoneySerializerTest {
+
+    @Mock
+    private JsonGenerator jsonGenerator;
+
+    @Mock
+    private SerializerProvider serializerProvider;
+
+    private MoneySerializer moneySerializer;
+
+    @BeforeEach
+    void setUp() {
+        moneySerializer = new MoneySerializer();
+    }
+
+    @Test
+    @DisplayName("Should write null when value is null")
+    void shouldWriteNullWhenValueIsNull() throws IOException {
+        // Act
+        moneySerializer.serialize(null, jsonGenerator, serializerProvider);
+
+        // Assert
+        verify(jsonGenerator).writeNull();
+        verifyNoMoreInteractions(jsonGenerator);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "150.5,   150.50",
+            "199.995, 200.00",
+            "199.994, 199.99",
+            "1000,    1000.00",
+            "123.45,  123.45"
+    })
+    @DisplayName("Should serialize BigDecimal values correctly")
+    void shouldSerializeBigDecimalValuesCorrectly(String inputValue, String expectedOutput) throws IOException {
+        // Arrange
+        BigDecimal value = new BigDecimal(inputValue);
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+
+        // Act
+        moneySerializer.serialize(value, jsonGenerator, serializerProvider);
+
+        // Assert
+        verify(jsonGenerator).writeString(stringCaptor.capture());
+        assertEquals(expectedOutput, stringCaptor.getValue());
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -53,6 +53,10 @@ public class WebSecurityConfig {
                                 ApiPathMatchers.TEST_MATCHER
                         ).permitAll()
                         .pathMatchers(
+                                HttpMethod.POST, ApiPathMatchers.DEBT_CAPACITY_MATCHER
+                        ).hasAnyAuthority(
+                                ApiConstants.Role.CALLBACK_ROLE
+                        ).pathMatchers(
                                 HttpMethod.POST, ApiPathMatchers.SOLICITUDE_MATCHER
                         ).hasAnyAuthority(
                                 ApiConstants.Role.CLIENT_ROLE_NAME

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -34,6 +34,7 @@ public class ApiConstants {
         public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
         public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
         public static final String SOLICITUDE_MATCHER = ApiPath.SOLICITUDE_PATH + "/**";
+        public static final String DEBT_CAPACITY_MATCHER = ApiPath.DEBT_CAPACITY_PATH + "/**";
         //ADMIN
         //TEST ENDPOINT
         public static final String TEST_MATCHER = "/test-endpoint";
@@ -45,6 +46,7 @@ public class ApiConstants {
         public static final String CLIENT_ROLE_NAME = "CLIENTE";
         public static final String ADMIN_ROLE_NAME = "ADMIN";
         public static final String ADVISOR_ROLE_NAME = "ASESOR";
+        public static final String CALLBACK_ROLE = "CALLBACK_ROLE";
 
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -10,11 +10,17 @@ public class ApiConstants {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class ApiPath {
         public static final String BASE_PATH = "/api/v1";
+        //Loan type
         public static final String LOAN_TYPE_PATH = BASE_PATH + "/tipoprestamo";
+        //State
         public static final String STATE_PATH = BASE_PATH + "/estado";
+        //Loan application
         public static final String SOLICITUDE_PATH = BASE_PATH + "/solicitud";
+        //Update State
         public static final String SOLICITUDE_UPDATE_PATH = SOLICITUDE_PATH + "/{id}";
-        public static final String API_REPORT_PATH = BASE_PATH + "/report";
+        //Calculate Debt capacity
+        public static final String DEBT_CAPACITY_PATH = BASE_PATH + "/calcular-capacidad";
+        //***********************
         public static final String SWAGGER_PATH = "/swagger-ui.html";
         public static final String DUMMY_SOLICITUDE_DOC_ROUTE = "/dummy-solicitude-doc-route";
         public static final String DUMMY_REPORT_DOC_ROUTE = "/dummy-report-doc-route";
@@ -27,10 +33,7 @@ public class ApiConstants {
         public static final String STATE_MATCHER = ApiPath.STATE_PATH + "/**";
         public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
         public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
-        //CLIENTE
         public static final String SOLICITUDE_MATCHER = ApiPath.SOLICITUDE_PATH + "/**";
-        //ASESOR
-        public static final String REPORT_MATCHER = ApiPath.API_REPORT_PATH + "/**";
         //ADMIN
         //TEST ENDPOINT
         public static final String TEST_MATCHER = "/test-endpoint";
@@ -191,11 +194,16 @@ public class ApiConstants {
         public static final String RES_401_DESC = "Unauthorized. A valid token is required.";
         public static final String RES_500_DESC = "Internal server error.";
 
-        // --- Request Schema ---
+        // --- Request Schema Status ---
         public static final String UPDATE_STATE_DESC = "The new state for the solicitude.";
         public static final String EXAMPLE_UPDATE_STATE = "APROBADO";
         public static final String APPROVED_STATE = "APROBADO";
         public static final String REJECTED_STATE = "RECHAZADO";
+        public static final String MANUAL_STATE = "MANUAL";
+
+        // --- Request Schema IdLoanApplication ---
+        public static final String ID_SOLICITUDE_DESC = "The id of the Loan Application for status update.";
+        public static final String EXAMPLE_ID_SOLICITUDE = "8";
     }
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class ApiOperations {
@@ -245,8 +253,6 @@ public class ApiConstants {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class SolicitudeDocs {
-        public static final String UPDATE_SOLICITUDE_STATUS_SUMMARY = "Update the status of a loan application for advisor's role only";
-        public static final String UPDATE_SOLICITUDE_STATUS_DESCRIPTION = "Updates the status of a specific loan application to 'APROBADO' or 'RECHAZADO'.";
         public static final String UPDATE_SOLICITUDE_STATUS_BODY_DESC = "The new status for the application.";
 
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/email/EmailMessageDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/email/EmailMessageDTO.java
@@ -1,0 +1,14 @@
+package co.com.pragma.api.dto.email;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class EmailMessageDTO {
+    private String to;
+    private String subject;
+    private String body;
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
@@ -1,0 +1,29 @@
+package co.com.pragma.api.dto.solicitude;
+
+import co.com.pragma.api.constants.ApiConstants.StateChangeDocs;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder(toBuilder = true)
+public class DebtCapacityRequestDTO {
+
+    @NotBlank
+    @Schema(
+            description = StateChangeDocs.ID_SOLICITUDE_DESC,
+            example = StateChangeDocs.EXAMPLE_ID_SOLICITUDE
+    )
+    private String idLoanApplication;
+
+    @NotBlank
+    @Schema(
+            description = StateChangeDocs.UPDATE_STATE_DESC,
+            example = StateChangeDocs.EXAMPLE_UPDATE_STATE,
+            allowableValues = {StateChangeDocs.APPROVED_STATE, StateChangeDocs.REJECTED_STATE, StateChangeDocs.MANUAL_STATE}
+    )
+    private String state;
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
@@ -17,7 +17,7 @@ public class DebtCapacityRequestDTO {
             description = StateChangeDocs.ID_SOLICITUDE_DESC,
             example = StateChangeDocs.EXAMPLE_ID_SOLICITUDE
     )
-    private String idLoanApplication;
+    private Integer solicitudeId;
 
     @NotBlank
     @Schema(

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/solicitude/DebtCapacityRequestDTO.java
@@ -3,16 +3,17 @@ package co.com.pragma.api.dto.solicitude;
 import co.com.pragma.api.constants.ApiConstants.StateChangeDocs;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 @Getter
 @Setter
 @Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
 public class DebtCapacityRequestDTO {
 
-    @NotBlank
+    @NotNull
     @Schema(
             description = StateChangeDocs.ID_SOLICITUDE_DESC,
             example = StateChangeDocs.EXAMPLE_ID_SOLICITUDE

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/mapper/email/EmailDTOMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/mapper/email/EmailDTOMapper.java
@@ -1,0 +1,10 @@
+package co.com.pragma.api.mapper.email;
+
+import co.com.pragma.api.dto.email.EmailMessageDTO;
+import co.com.pragma.model.template.EmailMessage;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface EmailDTOMapper {
+    EmailMessageDTO toDto(EmailMessage message);
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeHandler.java
@@ -84,4 +84,8 @@ public class SolicitudeHandler {
                                 .bodyValue(updatedSolicitude)
                 );
     }
+
+    public Mono<ServerResponse> listenPOSTDebtCapacityUseCase(ServerRequest serverRequest) {
+        return ServerResponse.ok().bodyValue("{}");
+    }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeHandler.java
@@ -1,7 +1,9 @@
 package co.com.pragma.api.solicitude;
 
+import co.com.pragma.api.dto.solicitude.DebtCapacityRequestDTO;
 import co.com.pragma.api.dto.solicitude.SolicitudeRequestDTO;
 import co.com.pragma.api.dto.solicitude.UpdateStatusRequestDTO;
+import co.com.pragma.api.mapper.email.EmailDTOMapper;
 import co.com.pragma.api.mapper.page.PageMapper;
 import co.com.pragma.api.mapper.report.FilterMapper;
 import co.com.pragma.api.mapper.report.SolicitudeReportMapper;
@@ -31,6 +33,7 @@ public class SolicitudeHandler {
     private final SolicitudeReportMapper solicitudeReportMapper;
     private final PageMapper pageMapper;
     private final JwtProviderPort jwtProvider;
+    private final EmailDTOMapper emailMapper;
 
 
     public Mono<ServerResponse> listenPOSTSaveSolicitudeUseCase(ServerRequest serverRequest) {
@@ -71,7 +74,7 @@ public class SolicitudeHandler {
         Integer solicitudeId = Integer.valueOf(serverRequest.pathVariable("id"));
         return serverRequest.bodyToMono(UpdateStatusRequestDTO.class)
                 .flatMap(updateRequest -> {
-                    String state =updateRequest.getState();
+                    String state = updateRequest.getState();
                     return solicitudeUseCase.approveRejectSolicitudeState(
                             solicitudeId,
                             state
@@ -86,6 +89,16 @@ public class SolicitudeHandler {
     }
 
     public Mono<ServerResponse> listenPOSTDebtCapacityUseCase(ServerRequest serverRequest) {
-        return ServerResponse.ok().bodyValue("{}");
+        return serverRequest.bodyToMono(DebtCapacityRequestDTO.class)
+                .flatMap(debtCapacityRequest ->
+                        solicitudeUseCase.debtCapacityStateChange(
+                                debtCapacityRequest.getSolicitudeId(),
+                                debtCapacityRequest.getState()
+                        ).map(emailMapper::toDto)
+                ).flatMap(email ->
+                        ServerResponse.ok()
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .bodyValue(email)
+                );
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeRouterRest.java
@@ -16,7 +16,7 @@ public class SolicitudeRouterRest {
                 .POST(ApiConstants.ApiPath.SOLICITUDE_PATH, handler::listenPOSTSaveSolicitudeUseCase)
                 .GET(ApiConstants.ApiPath.SOLICITUDE_PATH, handler::listenGETSolicitudeReportUseCase)
                 .PUT(ApiConstants.ApiPath.SOLICITUDE_UPDATE_PATH, handler::listenPUTUpdateSolicitudeStatusUseCase)
-                .PUT(ApiConstants.ApiPath.DEBT_CAPACITY_PATH, handler::listenPOSTDebtCapacityUseCase)
+                .POST(ApiConstants.ApiPath.DEBT_CAPACITY_PATH, handler::listenPOSTDebtCapacityUseCase)
                 .build();
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeRouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/SolicitudeRouterRest.java
@@ -16,6 +16,7 @@ public class SolicitudeRouterRest {
                 .POST(ApiConstants.ApiPath.SOLICITUDE_PATH, handler::listenPOSTSaveSolicitudeUseCase)
                 .GET(ApiConstants.ApiPath.SOLICITUDE_PATH, handler::listenGETSolicitudeReportUseCase)
                 .PUT(ApiConstants.ApiPath.SOLICITUDE_UPDATE_PATH, handler::listenPUTUpdateSolicitudeStatusUseCase)
+                .PUT(ApiConstants.ApiPath.DEBT_CAPACITY_PATH, handler::listenPOSTDebtCapacityUseCase)
                 .build();
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/documentation/SolicitudeDocumentation.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/solicitude/documentation/SolicitudeDocumentation.java
@@ -73,8 +73,8 @@ public class SolicitudeDocumentation {
                     beanMethod = "listenPUTUpdateSolicitudeStatusUseCase",
                     operation = @Operation(
                             operationId = ApiConstants.ApiOperations.OPERATION_UPDATE_SOLICITUDE_STATUS_ID,
-                            summary = ApiConstants.SolicitudeDocs.UPDATE_SOLICITUDE_STATUS_SUMMARY,
-                            description = ApiConstants.SolicitudeDocs.UPDATE_SOLICITUDE_STATUS_DESCRIPTION,
+                            summary = ApiConstants.StateChangeDocs.APPROVE_REJECT_OP_SUMMARY,
+                            description = ApiConstants.StateChangeDocs.APPROVE_REJECT_OP_DESC,
                             parameters = {
                                     @Parameter(in = ParameterIn.PATH, name = "id", required = true, description = ApiConstants.SolicitudeDocs.SOLICITUDE_ID_PARAM_DESCRIPTION, schema = @Schema(type = "integer", format = "int32"))
                             },

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
@@ -10,6 +10,7 @@ import co.com.pragma.api.dto.solicitude.SolicitudeResponseDTO;
 import co.com.pragma.api.exception.handler.CustomAccessDeniedHandler;
 import co.com.pragma.api.exception.handler.CustomAuthenticationEntryPoint;
 import co.com.pragma.api.exception.handler.GlobalExceptionHandler;
+import co.com.pragma.api.mapper.email.EmailDTOMapper;
 import co.com.pragma.api.mapper.page.PageMapper;
 import co.com.pragma.api.mapper.report.SolicitudeReportMapper;
 import co.com.pragma.api.mapper.solicitude.SolicitudeMapper;
@@ -79,6 +80,9 @@ class RouterRestTest {
 
     @MockitoBean
     private PageMapper pageMapper;
+
+    @MockitoBean
+    private EmailDTOMapper emailMapper;
 
     @Test
     @WithMockUser(authorities = "CLIENTE")

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
         GlobalExceptionHandler.class, WebSecurityConfig.class,
         CustomAccessDeniedHandler.class, CustomAuthenticationEntryPoint.class
 })
-@WebFluxTest
+@WebFluxTest(controllers = GlobalExceptionHandler.class)
 class RouterRestTest {
 
     @Autowired

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/config/ConfigTest.java
@@ -1,5 +1,6 @@
 package co.com.pragma.api.config;
 
+import co.com.pragma.api.mapper.email.EmailDTOMapper;
 import co.com.pragma.api.mapper.page.PageMapper;
 import co.com.pragma.api.mapper.report.SolicitudeReportMapper;
 import co.com.pragma.api.solicitude.SolicitudeHandler;
@@ -47,6 +48,9 @@ class ConfigTest {
 
     @MockitoBean
     private PageMapper pageMapper;
+
+    @MockitoBean
+    private EmailDTOMapper emailMapper;
 
     @Test
     void corsConfigurationShouldAllowOrigins() {


### PR DESCRIPTION
This pull request introduces several important enhancements and refactors to the solicitude management domain and supporting infrastructure. The main changes include making SQS and email notification handling fully reactive, introducing new domain models for debt capacity and email messages, updating error handling for SQS queues, and refactoring configuration and exception handling for improved maintainability and clarity.

**Key changes:**

### Notification and SQS Handling

- Refactored `SQSPort` to use reactive `Mono` methods and support sending both `EmailMessage` and new `DebtCapacity` messages, making notification sending non-blocking and more robust. (`[[1]](diffhunk://#diff-04110da9d0c68d25594b7004c96dcd8022f72410400b1f5e8a0dcfd0366f4d71R3-R11)`, `[[2]](diffhunk://#diff-2912009a9c02fb18752a099932ed33a6b788b892d547c9d05186cfe3d99e9885R1-R20)`, `[[3]](diffhunk://#diff-5fc824a7022549a6e04216193946b999c52ed23d7cabd8989b231b8067879b80R1-R14)`, `[[4]](diffhunk://#diff-3a18662ad95b4645910fb68cd66706dd1b9a58f2a6197ea1d520a4e90d441fcaR1-R8)`)
- Updated `SolicitudeUseCase` to use the new reactive notification flow, including proper error handling, transactional boundaries, and new methods for debt capacity state changes and pay plan notifications. (`[[1]](diffhunk://#diff-9a113d3c114239cc4daa399dcf328f77e80110e9e98ba5b1409a675d7a868a1cR7-R9)`, `[[2]](diffhunk://#diff-9a113d3c114239cc4daa399dcf328f77e80110e9e98ba5b1409a675d7a868a1cR21-L28)`, `[[3]](diffhunk://#diff-9a113d3c114239cc4daa399dcf328f77e80110e9e98ba5b1409a675d7a868a1cR42-R43)`, `[[4]](diffhunk://#diff-9a113d3c114239cc4daa399dcf328f77e80110e9e98ba5b1409a675d7a868a1cL51-R130)`)

### Error Handling and Exceptions

- Added a new nested `QueueError` class in `Errors` for more granular SQS queue error codes and messages. (`[domain/model/src/main/java/co/com/pragma/model/constants/Errors.javaR62-R69](diffhunk://#diff-4d8d09e97578b9c9e2b3a1076f8019aae7598cf52fc9484dd4b0ace2ce724d99R62-R69)`)
- Introduced `QueueAliasEmptyException` and `QueueNotFoundException` for better SQS queue error reporting, using the new error codes. (`[[1]](diffhunk://#diff-cc3d6d46af8dbee11574d782a306f0a57dee62655bf9087d0e38b8260517a4b2R1-R10)`, `[[2]](diffhunk://#diff-14c9b18d5b3ec64d8feb8e2feee426890d17a96483467094bf6dbd7ac4f350a4R1-R10)`)
- Refactored `UserNotFoundException` to use standardized error messages and codes. (`[domain/model/src/main/java/co/com/pragma/model/exceptions/UserNotFoundException.javaR3-R8](diffhunk://#diff-7cee93da33cb439e786b2a3ea20679960ede9224bc448437fd0a9ba1111ff852R3-R8)`)

### Domain Model Enhancements

- Added new domain models: `DebtCapacity`, `EmailMessage`, and `Installment` to support richer notification and debt calculation workflows. (`[[1]](diffhunk://#diff-2912009a9c02fb18752a099932ed33a6b788b892d547c9d05186cfe3d99e9885R1-R20)`, `[[2]](diffhunk://#diff-5fc824a7022549a6e04216193946b999c52ed23d7cabd8989b231b8067879b80R1-R14)`, `[[3]](diffhunk://#diff-3a18662ad95b4645910fb68cd66706dd1b9a58f2a6197ea1d520a4e90d441fcaR1-R8)`)
- Changed `EmailTemplate` from a static class to an enum for better type safety and extensibility. (`[domain/model/src/main/java/co/com/pragma/model/template/EmailTemplate.javaL3-R15](diffhunk://#diff-8c2df57450e2b694a347a229a89b3309f6a9790f2a4454f8f6b48988e0a79d9aL3-R15)`)
- Made the `TemplatePort.process` method reactive (`Mono<String>`), aligning with the overall reactive approach. (`[domain/model/src/main/java/co/com/pragma/model/template/gateways/TemplatePort.javaR3-R8](diffhunk://#diff-96c4902cecb70a635a7bdd9e010123655ddd8e6f9f37f139a2bf898f5b0840caR3-R8)`)

### Repository and JWT Enhancements

- Extended `SolicitudeRepository` with new methods for finding total monthly fee and fetching solicitudes by email. (`[domain/model/src/main/java/co/com/pragma/model/solicitude/gateways/SolicitudeRepository.javaR9-R22](diffhunk://#diff-763bec00aa370f5ac631c7f47bf279363b02972767d2a693929a2c209ee54bc9R9-R22)`)
- Added a `generateCallbackToken` method to `JwtProviderPort` for enhanced JWT handling. (`[domain/model/src/main/java/co/com/pragma/model/jwt/gateways/JwtProviderPort.javaR7](diffhunk://#diff-1c9a7e038b70e86d691fed2464d41ccea57b3fd46a29c8c6760bcab3f3ce9989R7)`)

### Configuration and Testing

- Updated SQS queue configuration structure in both AWS and local YAML files to support multiple queues by alias. (`[[1]](diffhunk://#diff-998f42cb3d9ab2e77809f155bd5c1402bfd82dc935a154b95b7c64525cf9ec99L4-R6)`, `[[2]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3L4-R6)`)
- Added unit tests for `ObjectMapperConfig` to ensure proper JSON serialization of dates. (`[applications/app-service/src/test/java/co/com/pragma/config/ObjectMapperConfigTest.javaR1-R59](diffhunk://#diff-ab358cf4ac319bade249eb2505462b986ed547f8f677a1ea84b1c4d6b94930cbR1-R59)`)
- Minor improvements in test configuration for mocking new ports. (`[[1]](diffhunk://#diff-4e11a17879e9a43aa269ca33903cc2d546aefac06aa38b0f43f1a43620275437R3)`, `[[2]](diffhunk://#diff-4e11a17879e9a43aa269ca33903cc2d546aefac06aa38b0f43f1a43620275437R82-R86)`)

These updates collectively modernize the notification and SQS integration, improve error handling, and lay the groundwork for more advanced workflows around debt capacity and email notifications.