### PR TITLE
HU 10

### DIFF
--- a/applications/app-service/src/main/resources/application-aws.yaml
+++ b/applications/app-service/src/main/resources/application-aws.yaml
@@ -1,7 +1,22 @@
-# Configuration for functional testing against a real AWS account
+spring:
+  flyway:
+    url: "jdbc:mysql://${SPRING_R2DBC_HOST:localhost}:${SPRING_R2DBC_PORT:3307}/${SPRING_R2DBC_DB:solicitudes_db}"
+    user: "${SPRING_DB_USERNAME:jpriva}"
+    password: "${SPRING_DB_PASSWORD:pass12345}"
+
 adapters:
   sqs:
     queues:
       state-change: "https://sqs.us-east-1.amazonaws.com/096187159240/solicitude-approved-queue"
       debt-capacity: "https://sqs.us-east-1.amazonaws.com/096187159240/debt-capacity-queue"
       metric: "https://sqs.us-east-1.amazonaws.com/096187159240/solicitude-report-queue"
+  r2dbc:
+    host: "${SPRING_R2DBC_HOST:localhost}"
+    port: "${SPRING_R2DBC_PORT:3307}"
+    database: "${SPRING_R2DBC_DB:solicitudes_db}"
+    username: "${SPRING_DB_USERNAME:jpriva}"
+    password: "${SPRING_DB_PASSWORD:pass12345}"
+
+security:
+  jwt:
+    secret: ${JWT_SECRET:iBdGbA8Dxowf12Zs7IYH91+KwKOg5yb39RGQv6pOWes=}

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -1,4 +1,9 @@
-# Configuration for local development using LocalStack
+spring:
+  flyway:
+    url: "jdbc:mysql://${SPRING_R2DBC_HOST:localhost}:${SPRING_R2DBC_PORT:3307}/${SPRING_R2DBC_DB:solicitudes_db}"
+    user: "${SPRING_DB_USERNAME:jpriva}"
+    password: "${SPRING_DB_PASSWORD:pass12345}"
+
 adapters:
   sqs:
     queues:
@@ -6,3 +11,13 @@ adapters:
       debt-capacity: "${ADAPTERS_SQS_ENDPOINT_OVERRIDE:http://localhost:4566}/000000000000/debt-capacity-queue"
       metric: "${ADAPTERS_SQS_ENDPOINT_OVERRIDE:http://localhost:4566}/000000000000/solicitude-report-queue"
     endpoint: "${ADAPTERS_SQS_ENDPOINT_OVERRIDE:http://localhost:4566}"
+  r2dbc:
+    host: "${SPRING_R2DBC_HOST:localhost}"
+    port: "${SPRING_R2DBC_PORT:3307}"
+    database: "${SPRING_R2DBC_DB:solicitudes_db}"
+    username: "${SPRING_DB_USERNAME:jpriva}"
+    password: "${SPRING_DB_PASSWORD:pass12345}"
+
+security:
+  jwt:
+    secret: ${JWT_SECRET:iBdGbA8Dxowf12Zs7IYH91+KwKOg5yb39RGQv6pOWes=}

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -1,0 +1,6 @@
+adapters:
+  sqs:
+    queues:
+      state-change: "${STATE_SQS_ENDPOINT_OVERRIDE:}"
+      debt-capacity: "${DEBT_SQS_ENDPOINT_OVERRIDE:}"
+      metric: "${METRIC_SQS_ENDPOINT_OVERRIDE:}"

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ spring:
   devtools:
     add-properties: false
   profiles:
-    active: "${SPRING_PROFILES_ACTIVE:aws}"
+    active: "${SPRING_PROFILES_ACTIVE:local}"
   flyway:
     url: "jdbc:mysql://${SPRING_R2DBC_HOST:localhost}:${SPRING_R2DBC_PORT:3307}/${SPRING_R2DBC_DB:solicitudes_db}"
     user: "${SPRING_DB_USERNAME:jpriva}"
@@ -32,6 +32,10 @@ adapters:
   sqs:
     region: "${ADAPTERS_SQS_REGION:us-east-1}"
     endpoint: "${ADAPTERS_SQS_ENDPOINT_OVERRIDE:}"
+    queues:
+      state-change: "${STATE_SQS_ENDPOINT_OVERRIDE:}"
+      debt-capacity: "${DEBT_SQS_ENDPOINT_OVERRIDE:}"
+      metric: "${METRIC_SQS_ENDPOINT_OVERRIDE:}"
     metrics:
       quantity: "${DYNAMO_QUANTITY_METRIC:quantity}"
       amount: "${DYNAMO_AMOUNT_METRIC:amount}"
@@ -48,7 +52,7 @@ management:
     port: 9091
 
 cors:
-  allowed-origins: "http://localhost:4200,http://localhost:8082"
+  allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8082}"
 springdoc:
   api-docs:
     info:

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -53,6 +53,14 @@ public class WebSecurityConfig {
                                 ApiPathMatchers.TEST_MATCHER
                         ).permitAll()
                         .pathMatchers(
+                                ApiPathMatchers.HEALTH_CHECK_MATCHER
+                        ).permitAll()
+                        .pathMatchers(
+                                ApiPathMatchers.ACTUATOR_MATCHER
+                        ).hasAnyAuthority(
+                                ApiConstants.Role.SUPER_USER_ROLE_NAME
+                        )
+                        .pathMatchers(
                                 HttpMethod.POST, ApiPathMatchers.DEBT_CAPACITY_MATCHER
                         ).hasAnyAuthority(
                                 ApiConstants.Role.CALLBACK_ROLE

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -33,6 +33,9 @@ public class ApiConstants {
         public static final String STATE_MATCHER = ApiPath.STATE_PATH + "/**";
         public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
         public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        //SUPER_USER
+        public static final String ACTUATOR_MATCHER = "/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
         public static final String SOLICITUDE_MATCHER = ApiPath.SOLICITUDE_PATH + "/**";
         public static final String DEBT_CAPACITY_MATCHER = ApiPath.DEBT_CAPACITY_PATH + "/**";
         //ADMIN
@@ -43,6 +46,7 @@ public class ApiConstants {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class Role {
+        public static final String SUPER_USER_ROLE_NAME = "SUPER_USER";
         public static final String CLIENT_ROLE_NAME = "CLIENTE";
         public static final String ADMIN_ROLE_NAME = "ADMIN";
         public static final String ADVISOR_ROLE_NAME = "ASESOR";


### PR DESCRIPTION
This pull request introduces several configuration and security improvements across the application, primarily focusing on environment-specific settings and enhanced authorization for actuator endpoints. The most important changes are grouped below by theme.

**Configuration enhancements and environment variables:**

* Added Flyway database migration and R2DBC connection settings to both `application-local.yaml` and `application-aws.yaml`, using environment variables for flexibility. [[1]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3L1-R23) [[2]](diffhunk://#diff-998f42cb3d9ab2e77809f155bd5c1402bfd82dc935a154b95b7c64525cf9ec99L1-R22)
* Introduced JWT secret configuration under a new `security.jwt.secret` property in both local and AWS configuration files. [[1]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3L1-R23) [[2]](diffhunk://#diff-998f42cb3d9ab2e77809f155bd5c1402bfd82dc935a154b95b7c64525cf9ec99L1-R22)
* Added SQS queue endpoint overrides in `application-prod.yaml` and `application.yaml` to support environment-specific queue configuration. [[1]](diffhunk://#diff-2aa382a3982f48798410bab12030ebaa4c9fc637bad08ac2a707c3dd2299aa37R1-R6) [[2]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948R35-R38)
* Made CORS allowed origins configurable via an environment variable in `application.yaml`.
* Changed the default active Spring profile from `aws` to `local` in `application.yaml` to facilitate local development.

**Security and authorization improvements:**

* Added new path matchers for actuator endpoints: `/actuator/**` (restricted to `SUPER_USER` role) and `/actuator/health/**` (permitted to all), enhancing granularity of access control.
* Introduced `SUPER_USER_ROLE_NAME` constant and corresponding path matcher constants in `ApiConstants.java` for clearer role management and endpoint mapping. [[1]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8R36-R38) [[2]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8R49)