### PR TITLE
Hu/10 deploy producction

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image to ECR
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Log in to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying Docker images to Amazon ECR. The changes add support for manual workflow dispatch, improve compatibility with Amazon ECR Public, and update the image path for public repositories.

**Workflow enhancements:**

* Added the ability to manually trigger the workflow using `workflow_dispatch`, allowing for on-demand builds and deployments.

**Amazon ECR Public support:**

* Updated the ECR login step to specify `registry-type: public`, ensuring the workflow can authenticate with Amazon ECR Public registries.
* Modified the Docker image path to include the public registry alias (`ECR_PUBLIC_ALIAS`), making image pushes compatible with Amazon ECR Public.