### PR TITLE
Develop

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image to ECR
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Log in to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -37,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying Docker images to Amazon ECR. The main improvements are to support manual workflow dispatch, enable login to public ECR registries, and update the image tagging process to use a public ECR alias.

**Workflow enhancements:**

* Added support for manual triggering of the workflow using `workflow_dispatch` in `.github/workflows/deploy-to-ecr.yml`.

**ECR configuration updates:**

* Modified the ECR login step to specify `registry-type: public`, allowing authentication with public ECR registries.
* Updated the Docker image naming to include the public ECR alias in the image path, ensuring images are pushed to the correct public repository.