### PR TITLE
Develop

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -48,8 +48,6 @@ management:
     health:
       probes:
         enabled: true
-  server:
-    port: 9091
 
 cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8082}"


### PR DESCRIPTION
This pull request makes a minor configuration update by removing the `server.port` setting from the `application.yaml` file. The application will now use the default server port unless specified elsewhere.