### PR TITLE
Update WebSecurityConfig error handling for consistent behavior

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -107,7 +107,7 @@ public class WebSecurityConfig {
                     return Mono.error(new InvalidCredentialsException());
                 }
             }
-            return Mono.error(new InvalidCredentialsException());
+            return Mono.empty();
         }
     }
 }


### PR DESCRIPTION
This pull request makes a small but important change to the authentication logic in the `WebSecurityConfig.java` file. Instead of returning an error when credentials are missing, the method now returns an empty `Mono`, which changes how unauthenticated requests are handled.

- Changed the fallback behavior in `load(ServerWebExchange exchange)` to return `Mono.empty()` instead of an error when credentials are missing, allowing for more flexible handling of unauthenticated requests.