### PR TITLE
Develop

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -107,7 +107,7 @@ public class WebSecurityConfig {
                     return Mono.error(new InvalidCredentialsException());
                 }
             }
-            return Mono.error(new InvalidCredentialsException());
+            return Mono.empty();
         }
     }
 }


### PR DESCRIPTION
This pull request makes a small change to the `WebSecurityConfig.java` file, modifying the behavior of the `load` method to return an empty `Mono` instead of an error when authentication information is missing or invalid. This likely changes how unauthenticated requests are handled in the security configuration.