### PR TITLE
Develop

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -58,8 +58,9 @@ springdoc:
       title: "Crediya Loan Application API Microservice"
       version: "1.0.0"
       description: "This is the API for Crediya Loan Application Microservice"
+    path: /solicitude/api-docs
   swagger-ui:
-    path: "/solicitude/swagger-ui.html"
+    path: /solicitude/swagger-ui.html
 security:
   jwt:
     secret: "${JWT_SECRET}"

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -31,11 +31,11 @@ public class ApiConstants {
         //PERMIT ALL
         public static final String LOAN_TYPE_MATCHER = ApiPath.LOAN_TYPE_PATH + "/**";
         public static final String STATE_MATCHER = ApiPath.STATE_PATH + "/**";
-        public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
-        public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        public static final String API_DOCS_MATCHER = "/solicitude/api-docs/**";
+        public static final String SWAGGER_UI_MATCHER = "/solicitude/swagger-ui/**";
         //SUPER_USER
-        public static final String ACTUATOR_MATCHER = "/actuator/**";
-        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
+        public static final String ACTUATOR_MATCHER = "/solicitude/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/solicitude/actuator/health/**";
         public static final String SOLICITUDE_MATCHER = ApiPath.SOLICITUDE_PATH + "/**";
         public static final String DEBT_CAPACITY_MATCHER = ApiPath.DEBT_CAPACITY_PATH + "/**";
         //ADMIN


### PR DESCRIPTION
This pull request updates the API documentation and actuator endpoint paths to be prefixed with `/solicitude`, ensuring consistency across the application's configuration and security matchers. This helps to namespace the API documentation and actuator endpoints, likely for better organization or multi-tenancy support.

**Configuration and Endpoint Path Updates:**

* Updated the `springdoc` configuration in `application.yaml` to set the OpenAPI docs and Swagger UI paths under `/solicitude` (`/solicitude/api-docs` and `/solicitude/swagger-ui.html`).
* Updated the security path matchers in `ApiConstants.java` so that the API docs, Swagger UI, and actuator endpoints are matched under the `/solicitude` prefix (e.g., `/solicitude/api-docs/**`, `/solicitude/swagger-ui/**`, `/solicitude/actuator/**`).